### PR TITLE
Update not matched variables

### DIFF
--- a/Assignments/CodingHW/aesgcm/aes_gcm.h
+++ b/Assignments/CodingHW/aesgcm/aes_gcm.h
@@ -26,6 +26,7 @@ class AESGCM{
          ~AESGCM();
         BYTE* tag = NULL; // pointer to message authentication code
         BYTE* ciphertext = NULL; // pointer to ciphertext
+        DWORD ctBufferSize = 0; // pointer to ciphertext size
         BCRYPT_AUTH_TAG_LENGTHS_STRUCT authTagLengths;
         DWORD ptBufferSize = 0; // pointer to plaintext size
         BYTE* plaintext = NULL; // pointer to plaintext

--- a/Assignments/CodingHW/aesgcm/aesgcm.cpp
+++ b/Assignments/CodingHW/aesgcm/aesgcm.cpp
@@ -89,7 +89,7 @@ void AESGCM::Cleanup(){
           tag = NULL;
     }
     if(ciphertext){
-        ::HeapFree(GetProcessHeap(), 0, tag);
+        ::HeapFree(GetProcessHeap(), 0, ciphertext);
         ciphertext = NULL;
     }
     if(plaintext){

--- a/Assignments/CodingHW/aesgcm/test_aesgcm.cpp
+++ b/Assignments/CodingHW/aesgcm/test_aesgcm.cpp
@@ -8,7 +8,7 @@ int main(){
     BYTE ciphertext[] ={0x3f, 0xc4, 0x4d, 0xa3, 0x55, 0xda, 0xf, 0x32, 0xb6, 0xd2, 0x89, 0x7b, 0x36, 0x90, 0x93, 0xbd, 0xf4, 0x8e, 0xeb, 0xd, 0x35, 0x24, 0xf0, 0xdc, 0x60, 0xaf, 0x39, 0xc5};
     auto box = new AESGCM(key);
     box->Encrypt( (BYTE*) textIV, sizeof(textIV), (BYTE*) message, sizeof(message));
-    box->Decrypt(textIV, sizeof(textIV), box->ciphertext, sizeof(message), box->tag, box->authTagLengths.dwMinLength );
+    box->Decrypt(textIV, sizeof(textIV), box->ciphertext, sizeof(box->ciphertext), box->tag, box->authTagLengths.dwMinLength );
     
     for(size_t i=0; i< box->ptBufferSize; i++){
         printf("%c", (char) box->plaintext[i]);

--- a/Assignments/CodingHW/aesgcm/test_aesgcm.cpp
+++ b/Assignments/CodingHW/aesgcm/test_aesgcm.cpp
@@ -8,7 +8,7 @@ int main(){
     BYTE ciphertext[] ={0x3f, 0xc4, 0x4d, 0xa3, 0x55, 0xda, 0xf, 0x32, 0xb6, 0xd2, 0x89, 0x7b, 0x36, 0x90, 0x93, 0xbd, 0xf4, 0x8e, 0xeb, 0xd, 0x35, 0x24, 0xf0, 0xdc, 0x60, 0xaf, 0x39, 0xc5};
     auto box = new AESGCM(key);
     box->Encrypt( (BYTE*) textIV, sizeof(textIV), (BYTE*) message, sizeof(message));
-    box->Decrypt(textIV, sizeof(textIV), box->ciphertext, sizeof(box->ciphertext), box->tag, box->authTagLengths.dwMinLength );
+    box->Decrypt(textIV, sizeof(textIV), box->ciphertext, box->ctBufferSize, box->tag, box->authTagLengths.dwMinLength );
     
     for(size_t i=0; i< box->ptBufferSize; i++){
         printf("%c", (char) box->plaintext[i]);


### PR DESCRIPTION
According to the purpose of testing on the created `ciphertext`, the size is not for the original `message`.